### PR TITLE
Alter -d behaviour to support using module name as the filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,10 @@ Values:
 
 Delimiter character to be used in modules filename.
 
-Default value is `-`.
+If you don't specify a delimiter, or pass -d without a value, then the component
+name in the HTML will be used unchanged as the filename. If you do specify a
+delimiter character, then the module name is broken into words, joined with the
+delimiter and lower-cased.
 
 ### output
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,7 +14,8 @@ var cli = meow(`
     Options
       -c, Type of generated React components. Default is 'es5'.
       -m, Type of generated JavaScript modules. Default is 'es6'.
-      -d, Delimiter character to be used in modules filename. Default is '-'.
+      -d, Delimiter character to be used in modules filename. Default is to
+          use module names unchanged.
       -o, Output directory path. Default is 'components'.
       -e, Output files extension. Default is 'js'.
 
@@ -39,7 +40,7 @@ glob(cli.input[0], function(err, files) {
     var component = extractReactComponents(html, {
       componentType: flags.c,
       moduleType: flags.m,
-      moduleFileNameDelimiter: flags.d,
+      moduleFileNameDelimiter: processDelimiterOption(flags.d),
       output: {
         path: flags.o,
         fileExtension: flags.e
@@ -62,3 +63,7 @@ glob(cli.input[0], function(err, files) {
   console.log(
     chalk.green(`Successfully generated ${chalk.red.bold(stats.count)} components: ${chalk.red.bold(stats.names.join(', '))}`));
 });
+
+function processDelimiterOption(flags_d) {
+  return (typeof flags_d === 'string' && flags_d !== '') ? flags_d : '';
+}

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -91,6 +91,7 @@ function htmlToReactComponentsLib(tree, options) {
   }
 
   var components = [];
+  var delimiter = options.moduleFileNameDelimiter || '';
 
   api.walk.bind(tree)(collectComponents(components));
 
@@ -103,7 +104,7 @@ function htmlToReactComponentsLib(tree, options) {
             .map(clearAndRenderComponents))));
 
   if (moduleType) {
-    return formatCode(toCode(toModules(moduleType, options.moduleFileNameDelimiter, reactComponents)), componentType, moduleType);
+    return formatCode(toCode(toModules(moduleType, delimiter, reactComponents)), componentType, moduleType);
   }
 
   return formatCode(toCode(reactComponents), componentType);

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -90,9 +90,6 @@ function htmlToReactComponentsLib(tree, options) {
     moduleType = 'es6';
   }
 
-
-  var delimiter = options.moduleFileNameDelimiter || '-';
-
   var components = [];
 
   api.walk.bind(tree)(collectComponents(components));
@@ -106,7 +103,7 @@ function htmlToReactComponentsLib(tree, options) {
             .map(clearAndRenderComponents))));
 
   if (moduleType) {
-    return formatCode(toCode(toModules(moduleType, delimiter, reactComponents)), componentType, moduleType);
+    return formatCode(toCode(toModules(moduleType, options.moduleFileNameDelimiter, reactComponents)), componentType, moduleType);
   }
 
   return formatCode(toCode(reactComponents), componentType);

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -4,6 +4,10 @@ var mkdirp = require('mkdirp');
 
 function toFileName(delimiter, name) {
 
+  if (delimiter === '') {
+    return name;
+  }
+
   return name.replace(/[a-z][A-Z]/g, function(str) {
     return str[0] + delimiter + str[1];
   }).toLowerCase();
@@ -14,7 +18,6 @@ function writeToFS(components, options, moduleFileNameDelimiter) {
   options = options || {};
 
   var outPath = options.path || 'components';
-  var delimiter = moduleFileNameDelimiter || '-';
   var ext = options.fileExtension || 'js';
 
   mkdirp.sync(path.join(process.cwd(), outPath));
@@ -23,7 +26,7 @@ function writeToFS(components, options, moduleFileNameDelimiter) {
     .forEach(function(name) {
 
       fs.writeFileSync(
-        path.join(outPath, toFileName(delimiter, name)) + '.' + ext,
+        path.join(outPath, toFileName(moduleFileNameDelimiter, name)) + '.' + ext,
         components[name],
         'utf8');
     });

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -18,6 +18,7 @@ function writeToFS(components, options, moduleFileNameDelimiter) {
   options = options || {};
 
   var outPath = options.path || 'components';
+  var delimiter = moduleFileNameDelimiter || '';
   var ext = options.fileExtension || 'js';
 
   mkdirp.sync(path.join(process.cwd(), outPath));
@@ -26,7 +27,7 @@ function writeToFS(components, options, moduleFileNameDelimiter) {
     .forEach(function(name) {
 
       fs.writeFileSync(
-        path.join(outPath, toFileName(moduleFileNameDelimiter, name)) + '.' + ext,
+        path.join(outPath, toFileName(delimiter, name)) + '.' + ext,
         components[name],
         'utf8');
     });


### PR DESCRIPTION
As discussed on PR #2, update the -d option to support using module name as the filename.