### PR TITLE
Support browserify by skipping magic plugin loading

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -1,4 +1,6 @@
 var esformatter = require('esformatter');
+var esformatterQuotes = require('esformatter-quotes');
+var esformatterJsx = require('esformatter-jsx');
 var tk = require('rocambole-token');
 
 var defaultOpts = {
@@ -16,6 +18,11 @@ var defaultOpts = {
     type: 'single',
     avoidEscape: false
   }
+};
+
+var plugins = {
+  'esformatter-quotes': esformatterQuotes,
+  'esformatter-jsx': esformatterJsx
 };
 
 function getES6Config(opts) {
@@ -80,6 +87,14 @@ function formatCode(components, componentType, moduleType) {
     config = getStatelessComponentConfig(config);
     setStatelessComponentFormatter();
   }
+
+  // skip the auto-load mechanism to support Browserify
+  config.plugins.forEach(function(plugin) {
+    esformatter.register(plugins[plugin]);
+  });
+
+  // disable the auto-load mechanism
+  delete config.plugins;
 
   return Object.keys(components)
     .reduce(function(cs, name) {


### PR DESCRIPTION
esformatter's plugin loading depends on a filesystem being present from which it
can read the node_modules directory (more here:
https://github.com/millermedeiros/esformatter/blob/master/doc/plugins.md).

Browserify bundles don't have a filesystem, so their dependencies need to be
required explicitly.

Without this fix, browserified bundles are required to understand the inner
workings of this module, and also use the following magic incantation with
browserify

`browserify -r esformatter-quotes -r esformatter-jsx index.js > out.js`