### PR TITLE
Conditionally exclude FS writing with env var

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,10 @@
 var parse = require('posthtml-parser');
 var htmlToReactComponentsLib = require('./processor');
-var writeToFS = require('./writer').writeToFS;
+var writeToFS;
+
+if (!process.env.NO_WRITE_FS) {
+  writeToFS = require('./writer').writeToFS;
+}
 
 module.exports = function extractReactComponents(html, options) {
 
@@ -8,7 +12,9 @@ module.exports = function extractReactComponents(html, options) {
 
   var components = htmlToReactComponentsLib(parse(html), options);
 
-  writeToFS(components, options.output, options.moduleFileNameDelimiter);
+  if (!process.env.NO_WRITE_FS) {
+    writeToFS(components, options.output, options.moduleFileNameDelimiter);
+  }
 
   return components;
 };

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,6 +1,4 @@
-var fs = require('fs');
-var path = require('path');
-var mkdirp = require('mkdirp');
+var fs, path, mkdirp;
 
 function toFileName(delimiter, name) {
 
@@ -13,27 +11,41 @@ function toFileName(delimiter, name) {
   }).toLowerCase();
 }
 
-function writeToFS(components, options, moduleFileNameDelimiter) {
+if (!process.env.NO_WRITE_FS) {
 
-  options = options || {};
+  fs = require('fs');
+  path = require('path');
+  mkdirp = require('mkdirp');
 
-  var outPath = options.path || 'components';
-  var delimiter = moduleFileNameDelimiter || '';
-  var ext = options.fileExtension || 'js';
+  function writeToFS(components, options, moduleFileNameDelimiter) { // eslint-disable-line no-inner-declarations
 
-  mkdirp.sync(path.join(process.cwd(), outPath));
+    options = options || {};
 
-  Object.keys(components)
-    .forEach(function(name) {
+    var outPath = options.path || 'components';
+    var delimiter = moduleFileNameDelimiter || '';
+    var ext = options.fileExtension || 'js';
 
-      fs.writeFileSync(
-        path.join(outPath, toFileName(delimiter, name)) + '.' + ext,
-        components[name],
-        'utf8');
-    });
+    mkdirp.sync(path.join(process.cwd(), outPath));
+
+    Object.keys(components)
+      .forEach(function(name) {
+
+        fs.writeFileSync(
+          path.join(outPath, toFileName(delimiter, name)) + '.' + ext,
+          components[name],
+          'utf8');
+      });
+  }
+
+  module.exports = {
+    toFileName: toFileName,
+    writeToFS: writeToFS
+  };
+
+} else {
+
+  module.exports = {
+    toFileName: toFileName
+  };
+
 }
-
-module.exports = {
-  toFileName: toFileName,
-  writeToFS: writeToFS
-};


### PR DESCRIPTION
Enables smaller browserify builds when combined with envify and uglifyify.

For example, with an invocation such as:

```
browserify -g uglifyify -t [ envify --NO_WRITE_FS ] index.js > out.js
```

Will conditionally exclude all the write to fs files (including the node `fs` module which doesn't work in the browser anyway.

*note*: The changeset is much better viewed with whitespace differences turned off: https://github.com/roman01la/html-to-react-components/pull/8/files?w=0 (due to indentation of a function)