### PR TITLE
add hooks to allow user to manipulate asts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 test/*.actual.html
 components
 coverage
+.coveralls.yml

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ extractReactComponents(
 `,
 {
   componentType: 'stateless',
-  moduleType: false
+  moduleType: false,
+  afterASTHook: function(asts) {
+    // manipulate asts
+    return asts
+  }
 });
 
 /*

--- a/lib/component.js
+++ b/lib/component.js
@@ -69,8 +69,14 @@ function toReactComponents(componentType, components) {
   return Object.keys(components)
     .reduce(function(cs, name) {
 
+      var body = getAST(
+        name,
+        components[name].body.program.body[0].expression,
+        componentType
+      );
+
       cs[name] = {
-        body: getAST(name, components[name].body.program.body[0].expression, componentType),
+        body: body,
         children: components[name].children
       };
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -95,13 +95,15 @@ function htmlToReactComponentsLib(tree, options) {
 
   api.walk.bind(tree)(collectComponents(components));
 
-  var reactComponents = toReactComponents(
-      componentType,
-      toJsxAST(
-        mergeByName(
-          components
-            .map(assignByName)
-            .map(clearAndRenderComponents))));
+  var unmergedComponents = components
+    .map(assignByName)
+    .map(clearAndRenderComponents);
+
+  var jsxASTs = toJsxAST(mergeByName(unmergedComponents));
+  var reactComponents = toReactComponents(componentType, jsxASTs);
+  if (options.afterASTHook) {
+    reactComponents = options.afterASTHook(reactComponents);
+  }
 
   if (moduleType) {
     return formatCode(toCode(toModules(moduleType, delimiter, reactComponents)), componentType, moduleType);


### PR DESCRIPTION
This is more of a suggestion instead of a PR.

@roman01la We want to extend the function of this component and do something like this:
```
<C1 data-props-users="users">
  <C2 data-props-user="users">
  <C2 data-props-user="users">
  <C2 data-props-user="users">
</C1>
// CONVERT TO
<C1>
  {
    this.props.users.map(
      function(user){ return <C2 user={user}> }
    )
  }
</C1>
```

Or something like this
```
<C1>
   user's name is <span data-value="user.name">John</span>,
   he has a car named <span data-value="car.name">Toyota</span>
</C1>
// CONVERT TO
<C1>
   user's name is <span>{this.props.user.name}</span>,
   he has a car named <span>{this.props.car.name}</span>
</C1>
```

There are several solutions for us:
1. fork you repo and do PRs.
2. extend your repo a little bit to allow users to hook into their own functionality into the conversion flow.

I am trying to do the second one. What do you think is the best?

BTW, thank you for your awesome package! 