### PR TITLE
Fix for ignoring passed in output directory and file extension

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -20,9 +20,9 @@ if (typeof IN_BROWSER === "undefined") {
   function writeToFS(components, options) {
     options = options || {}
 
-    var outPath = path.resolve(options.path || "components")
+    var outPath = path.resolve(options.output && options.output.path ? options.output.path : "components")
     var delimiter = options.moduleFileNameDelimiter || ""
-    var ext = options.fileExtension || "js"
+    var ext = options.output && options.output.fileExtension ? options.output.fileExtension : "js"
 
     mkdirp.sync(outPath)
 


### PR DESCRIPTION
Hi Roman,

Here's a small fix for the output directory and file extension command line parameters being ignored and always using the defaults. All tests still pass.

Thanks,

Ben.